### PR TITLE
Added possibility to override the default default 2 second onUpdate interval.

### DIFF
--- a/fetch/src/main/java/com/tonyodev/fetch/Fetch.java
+++ b/fetch/src/main/java/com/tonyodev/fetch/Fetch.java
@@ -1023,6 +1023,19 @@ public final class Fetch implements FetchConst {
     }
 
     /**
+     * Sets the desired interval for the desired "onUpdate" calls during file download.
+     *
+     * @param intervalMs the milliseconds interval
+     *
+     * @throws NotUsableException if the release method has been called on Fetch.
+     */
+    public void setOnUpdateInterval(long intervalMs) {
+
+        Utils.throwIfNotUsable(this);
+        new Settings(context).setOnUpdateInterval(intervalMs).apply();
+    }
+
+    /**
      * Updates the url for an existing request
      *
      * @param id request id
@@ -1122,6 +1135,23 @@ public final class Fetch implements FetchConst {
             Bundle extras = new Bundle();
             extras.putInt(FetchService.ACTION_TYPE,FetchService.ACTION_CONCURRENT_DOWNLOADS_LIMIT);
             extras.putInt(FetchService.EXTRA_CONCURRENT_DOWNLOADS_LIMIT,limit);
+            settings.add(extras);
+
+            return this;
+        }
+
+        /**
+         * Sets the desired interval for the desired "onUpdate" calls during file download.
+         *
+         * @param intervalMs the milliseconds interval
+         *
+         * @return the settings instance
+         */
+        public Settings setOnUpdateInterval(long intervalMs) {
+
+            Bundle extras = new Bundle();
+            extras.putInt(FetchService.ACTION_TYPE,FetchService.ACTION_ON_UPDATE_INTERVAL);
+            extras.putLong(FetchService.EXTRA_ON_UPDATE_INTERVAL,intervalMs);
             settings.add(extras);
 
             return this;

--- a/fetch/src/main/java/com/tonyodev/fetch/FetchConst.java
+++ b/fetch/src/main/java/com/tonyodev/fetch/FetchConst.java
@@ -173,6 +173,11 @@ interface FetchConst {
     int DEFAULT_DOWNLOADS_LIMIT = 1;
 
     /**
+     * Default ms interval for the call to "onUpdate".
+     * */
+    long DEFAULT_ON_UPDATE_INTERVAL = 2000;
+
+    /**
      * Max concurrent downloads limit.
      * @deprecated Use your best judgement
      * */

--- a/fetch/src/main/java/com/tonyodev/fetch/FetchRunnable.java
+++ b/fetch/src/main/java/com/tonyodev/fetch/FetchRunnable.java
@@ -49,6 +49,7 @@ final class FetchRunnable implements Runnable {
     private final String filePath;
     private final List<Header> headers;
     private final boolean loggingEnabled;
+    private final long onUpdateInterval;
 
     private final Context context;
     private final LocalBroadcastManager broadcastManager;
@@ -70,7 +71,8 @@ final class FetchRunnable implements Runnable {
     }
 
     FetchRunnable(@NonNull Context context, long id,@NonNull String url,@NonNull String filePath,
-                  @NonNull List<Header> headers,long fileSize,boolean loggingEnabled) {
+                  @NonNull List<Header> headers,long fileSize,boolean loggingEnabled,
+                  long onUpdateInterval) {
 
         if(context == null) {
             throw new NullPointerException("Context cannot be null");
@@ -98,6 +100,7 @@ final class FetchRunnable implements Runnable {
         this.broadcastManager = LocalBroadcastManager.getInstance(this.context);
         this.databaseHelper = DatabaseHelper.getInstance(this.context);
         this.loggingEnabled = loggingEnabled;
+        this.onUpdateInterval = onUpdateInterval;
         this.databaseHelper.setLoggingEnabled(loggingEnabled);
     }
 
@@ -259,7 +262,7 @@ final class FetchRunnable implements Runnable {
 
             stopTime = System.nanoTime();
 
-            if (Utils.hasTwoSecondsPassed(startTime,stopTime) && !isInterrupted()) {
+            if (Utils.hasIntervalElapsed(startTime,stopTime,onUpdateInterval) && !isInterrupted()) {
 
                 progress = Utils.getProgress(downloadedBytes,fileSize);
 

--- a/fetch/src/main/java/com/tonyodev/fetch/FetchService.java
+++ b/fetch/src/main/java/com/tonyodev/fetch/FetchService.java
@@ -303,7 +303,7 @@ public final class FetchService extends Service implements FetchConst {
                             break;
                         }
                         case ACTION_ON_UPDATE_INTERVAL: {
-                            long interval = intent.getIntExtra(EXTRA_ON_UPDATE_INTERVAL, DEFAULT_DOWNLOADS_LIMIT);
+                            long interval = intent.getLongExtra(EXTRA_ON_UPDATE_INTERVAL, DEFAULT_ON_UPDATE_INTERVAL);
                             setOnUpdateInterval(interval);
                             break;
                         }
@@ -812,6 +812,7 @@ public final class FetchService extends Service implements FetchConst {
     }
 
     private long getOnUpdateInterval() {
-        return sharedPreferences.getLong(EXTRA_ON_UPDATE_INTERVAL, DEFAULT_ON_UPDATE_INTERVAL);
+        onUpdateInterval = sharedPreferences.getLong(EXTRA_ON_UPDATE_INTERVAL, DEFAULT_ON_UPDATE_INTERVAL);
+        return onUpdateInterval;
     }
 }

--- a/fetch/src/main/java/com/tonyodev/fetch/FetchService.java
+++ b/fetch/src/main/java/com/tonyodev/fetch/FetchService.java
@@ -74,6 +74,7 @@ public final class FetchService extends Service implements FetchConst {
     public static final String EXTRA_QUERY_TYPE = "com.tonyodev.fetch.extra_query_type";
     public static final String EXTRA_LOGGING_ID = "com.tonyodev.fetch.extra_logging_id";
     public static final String EXTRA_CONCURRENT_DOWNLOADS_LIMIT = "com.tonyodev.fetch.extra_concurrent_download_limit";
+    public static final String EXTRA_ON_UPDATE_INTERVAL = "com.tonyodev.fetch.extra_on_update_interval";
 
     public static final String ACTION_TYPE = "com.tonyodev.fetch.action_type";
 
@@ -89,7 +90,8 @@ public final class FetchService extends Service implements FetchConst {
     public static final int ACTION_REMOVE_ALL = 319;
     public static final int ACTION_LOGGING = 320;
     public static final int ACTION_CONCURRENT_DOWNLOADS_LIMIT = 321;
-    public static final int ACTION_UPDATE_REQUEST_URL = 322;
+    public static final int ACTION_ON_UPDATE_INTERVAL = 322;
+    public static final int ACTION_UPDATE_REQUEST_URL = 323;
 
     public static final int QUERY_SINGLE = 480;
     public static final int QUERY_ALL = 481;
@@ -106,6 +108,7 @@ public final class FetchService extends Service implements FetchConst {
     private volatile boolean shuttingDown = false;
     private int downloadsLimit = DEFAULT_DOWNLOADS_LIMIT;
     private boolean loggingEnabled = true;
+    private long onUpdateInterval = DEFAULT_ON_UPDATE_INTERVAL;
     private int preferredNetwork = NETWORK_ALL;
     private final ExecutorService executor = Executors.newSingleThreadExecutor();
     private final List<BroadcastReceiver> registeredReceivers = new ArrayList<>();
@@ -170,6 +173,7 @@ public final class FetchService extends Service implements FetchConst {
         downloadsLimit = getDownloadsLimit();
         preferredNetwork = getAllowedNetwork();
         loggingEnabled = isLoggingEnabled();
+        onUpdateInterval = getOnUpdateInterval();
         databaseHelper.setLoggingEnabled(loggingEnabled);
 
         if(!executor.isShutdown()) {
@@ -298,6 +302,11 @@ public final class FetchService extends Service implements FetchConst {
                             setDownloadsLimit(limit);
                             break;
                         }
+                        case ACTION_ON_UPDATE_INTERVAL: {
+                            long interval = intent.getIntExtra(EXTRA_ON_UPDATE_INTERVAL, DEFAULT_DOWNLOADS_LIMIT);
+                            setOnUpdateInterval(interval);
+                            break;
+                        }
                         case ACTION_UPDATE_REQUEST_URL: {
                             String url = intent.getStringExtra(EXTRA_URL);
                             updateRequestUrl(id,url);
@@ -343,7 +352,7 @@ public final class FetchService extends Service implements FetchConst {
 
                     FetchRunnable fetchRunnable = new FetchRunnable(context,requestInfo.getId(),
                             requestInfo.getUrl(), requestInfo.getFilePath()
-                            ,requestInfo.getHeaders(),requestInfo.getFileSize(),loggingEnabled);
+                            ,requestInfo.getHeaders(),requestInfo.getFileSize(),loggingEnabled, onUpdateInterval);
 
                     databaseHelper.updateStatus(requestInfo.getId(),FetchService.STATUS_DOWNLOADING,DEFAULT_EMPTY_VALUE);
                     activeDownloads.put(fetchRunnable.getId(),fetchRunnable);
@@ -794,5 +803,15 @@ public final class FetchService extends Service implements FetchConst {
     static boolean isLoggingEnabled(Context context) {
         return  context.getSharedPreferences(SHARED_PREFERENCES,Context.MODE_PRIVATE)
                 .getBoolean(EXTRA_LOGGING_ID,true);
+    }
+
+    private void setOnUpdateInterval(long intervalMs) {
+        onUpdateInterval = intervalMs;
+        sharedPreferences.edit().putLong(EXTRA_ON_UPDATE_INTERVAL, intervalMs).apply();
+        startDownload();
+    }
+
+    private long getOnUpdateInterval() {
+        return sharedPreferences.getLong(EXTRA_ON_UPDATE_INTERVAL, DEFAULT_ON_UPDATE_INTERVAL);
     }
 }

--- a/fetch/src/main/java/com/tonyodev/fetch/Utils.java
+++ b/fetch/src/main/java/com/tonyodev/fetch/Utils.java
@@ -74,10 +74,10 @@ final class Utils {
                         ,ErrorUtils.INVALID_STATUS);
         }
     }
+    
+    static boolean hasIntervalElapsed(long startTime, long stopTime, long onUpdateInterval) {
 
-    static boolean hasTwoSecondsPassed(long startTime, long stopTime) {
-
-        if(TimeUnit.NANOSECONDS.toSeconds(stopTime - startTime) >= 2) {
+        if(TimeUnit.NANOSECONDS.toMillis(stopTime - startTime) >= onUpdateInterval) {
             return true;
         }
 


### PR DESCRIPTION
Following the suggestion in the issue:
https://github.com/tonyofrancis/Fetch/issues/60

Added a simple ability to set the desired update interval for onUpdate to be called.
Set the desired interval in milliseconds.

Easy to use:
`fetch.setOnUpdateInterval(250);`
