### PR TITLE
Fix for #133

### DIFF
--- a/fetch2/src/main/java/com/tonyodev/fetch2/downloader/FileDownloaderImpl.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/downloader/FileDownloaderImpl.kt
@@ -81,7 +81,7 @@ class FileDownloaderImpl(private val initialDownload: Download,
                 } else if (!isResponseSuccessful && !interrupted && !terminated) {
                     throw FetchException(RESPONSE_NOT_SUCCESSFUL,
                             FetchException.Code.REQUEST_NOT_SUCCESSFUL)
-                } else if(!interrupted && !terminated) {
+                } else if (!interrupted && !terminated) {
                     throw FetchException(UNKNOWN_ERROR,
                             FetchException.Code.UNKNOWN)
                 }
@@ -102,12 +102,20 @@ class FileDownloaderImpl(private val initialDownload: Download,
                 var error = getErrorFromThrowable(e)
                 error.throwable = e
                 if (retryOnNetworkGain) {
-                    try {
-                        Thread.sleep(5000)
-                    } catch (e: InterruptedException) {
-                        logger.e("FileDownloader", e)
+                    var disconnectDetected = !networkInfoProvider.isNetworkAvailable
+                    for(i in 1..10) {
+                        try {
+                            Thread.sleep(500)
+                        } catch (e: InterruptedException) {
+                            logger.e("FileDownloader", e)
+                            break;
+                        }
+                        if (!networkInfoProvider.isNetworkAvailable) {
+                            disconnectDetected = true
+                            break;
+                        }
                     }
-                    if (!networkInfoProvider.isNetworkAvailable) {
+                    if (disconnectDetected) {
                         error = Error.NO_NETWORK_CONNECTION
                     }
                 }


### PR DESCRIPTION
Check if there's no connectivity right when we receive a download error. If there's connectivity, poll the  connectivity manager every 500ms, up to a total time of 5s, trying to detect a disconnect, and breaking immediately if one is detected.

If any disconnect is detected during that process, consider the error a `NO_NETWORK_CONNECTION` error (therefore eligible for retry if `enableRetryOnNetworkGain` is true).