### PR TITLE
fix android 9+ requires opt-in for unencrypted traffic

### DIFF
--- a/sampleApp/src/main/AndroidManifest.xml
+++ b/sampleApp/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.tonyodev.fetchapp">
+          xmlns:tools="http://schemas.android.com/tools"
+          package="com.tonyodev.fetchapp">
 
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
@@ -11,9 +12,11 @@
         android:allowBackup="false"
         android:icon="@mipmap/ic_launcher"
         android:label="@string/app_name"
+        android:networkSecurityConfig="@xml/network_security_config"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        tools:targetApi="n">
         <activity android:name=".MainActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />

--- a/sampleApp/src/main/res/xml/network_security_config.xml
+++ b/sampleApp/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,4 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+    <base-config cleartextTrafficPermitted="true"/>
+</network-security-config>


### PR DESCRIPTION
Starting with Android 9, network request requires opt-in for unencrypted traffic or else it will block the network request as shown below. To recreate this issue, just test Android 9 (Pie) in emulator.

Relevent documentation https://developer.android.com/training/articles/security-config

```
2018-10-24 12:54:27.641 8314-8341/com.tonyodev.fetchapp E/LibGlobalFetchLib: FileDownloader download:DownloadInfo(id=-1280178996, namespace='LibGlobalFetchLib', url='http://speedtest.ftp.otenet.gr/files/test100Mb.db', file='/storage/emulated/0/Download/fetch/movies/test100Mb.db', group=0, priority=NORMAL, headers={}, downloaded=0, total=-1, status=QUEUED, error=NONE, networkType=ALL, created=1540400066947, tag=null, enqueueAction=UPDATE_ACCORDINGLY, identifier=0, downloadOnEnqueue=true, extras={"testBoolean":"true","testString":"test","testFloat":"1.4E-45","testDouble":"4.9E-324","testInt":"2147483647","testLong":"9223372036854775807"})
    java.io.IOException: Cleartext HTTP traffic to speedtest.ftp.otenet.gr not permitted
        at com.android.okhttp.HttpHandler$CleartextURLFilter.checkURLPermitted(HttpHandler.java:115)
        at com.android.okhttp.internal.huc.HttpURLConnectionImpl.execute(HttpURLConnectionImpl.java:458)
        at com.android.okhttp.internal.huc.HttpURLConnectionImpl.connect(HttpURLConnectionImpl.java:127)
        at com.tonyodev.fetch2.HttpUrlConnectionDownloader.execute(HttpUrlConnectionDownloader.kt:46)
        at com.tonyodev.fetch2.downloader.ParallelFileDownloaderImpl.run(ParallelFileDownloaderImpl.kt:93)
        at com.tonyodev.fetch2.downloader.DownloadManagerImpl$start$$inlined$synchronized$lambda$1.run(DownloadManagerImpl.kt:97)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1167)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:641)
        at java.lang.Thread.run(Thread.java:764)
```