### PR TITLE
Allow to query group downloads by multiple statuses

### DIFF
--- a/fetch2/src/main/java/com/tonyodev/fetch2/Fetch.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/Fetch.kt
@@ -321,22 +321,22 @@ interface Fetch {
     /**
      * Remove all downloads with the specified group and status in this instance of Fetch.
      * The downloaded files for removed downloads are not deleted.
-     * @param status status
+     * @param statuses statuses
      * @param func callback returning a list of downloads that were removed.
      * @param func2 Callback that is called when attempting to remove downloads fail. An error is returned.
      * @throws FetchException if this instance of Fetch has been closed.
      * @return Instance
      * */
-    fun removeAllInGroupWithStatus(id: Int, status: Status, func: Func<List<Download>>?, func2: Func<Error>? = null): Fetch
+    fun removeAllInGroupWithStatus(id: Int, statuses: List<Status>, func: Func<List<Download>>?, func2: Func<Error>? = null): Fetch
 
     /**
      * Remove all downloads with the specified group and status in this instance of Fetch.
      * The downloaded files for removed downloads are not deleted.
-     * @param status status
+     * @param statuses statuses
      * @throws FetchException if this instance of Fetch has been closed.
      * @return Instance
      * */
-    fun removeAllInGroupWithStatus(id: Int, status: Status): Fetch
+    fun removeAllInGroupWithStatus(id: Int, statuses: List<Status>): Fetch
 
     /**
      * Delete a list of downloads managed by this instance of Fetch.
@@ -438,22 +438,22 @@ interface Fetch {
     /**
      * Deletes all downloads with the specified group and status in this instance of Fetch.
      * The downloaded files are also deleted.
-     * @param status status
+     * @param statuses statuses
      * @param func callback returns all deleted downloads with a specified status.
      * @param func2 Callback that is called when attempting to delete downloads fail. An error is returned.
      * @throws FetchException if this instance of Fetch has been closed.
      * @return Instance
      * */
-    fun deleteAllInGroupWithStatus(id: Int, status: Status, func: Func<List<Download>>?, func2: Func<Error>? = null): Fetch
+    fun deleteAllInGroupWithStatus(id: Int, statuses: List<Status>, func: Func<List<Download>>?, func2: Func<Error>? = null): Fetch
 
     /**
      * Deletes all downloads with the specified group and status in this instance of Fetch.
      * The downloaded files are also deleted.
-     * @param status status
+     * @param statuses statuses
      * @throws FetchException if this instance of Fetch has been closed.
      * @return Instance
      * */
-    fun deleteAllInGroupWithStatus(id: Int, status: Status): Fetch
+    fun deleteAllInGroupWithStatus(id: Int, statuses: List<Status>): Fetch
 
     /**
      * Cancel a list of non completed downloads managed by this instance of Fetch.
@@ -645,12 +645,12 @@ interface Fetch {
      * Gets all downloads in a specific group with a specific status.
      * @see com.tonyodev.fetch2.Status
      * @param groupId group id to query.
-     * @param status Status to query.
+     * @param statuses Statuses to query.
      * @param func Callback that the results will be returned on.
      * @throws FetchException if this instance of Fetch has been closed.
      * @return Instance
      * */
-    fun getDownloadsInGroupWithStatus(groupId: Int, status: Status, func: Func<List<Download>>): Fetch
+    fun getDownloadsInGroupWithStatus(groupId: Int, statuses: List<Status>, func: Func<List<Download>>): Fetch
 
     /**
      * Gets all downloads containing the identifier.

--- a/fetch2/src/main/java/com/tonyodev/fetch2/database/DatabaseManager.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/database/DatabaseManager.kt
@@ -26,7 +26,7 @@ interface DatabaseManager : Closeable {
     fun getByFile(file: String): DownloadInfo?
     fun getByStatus(status: Status): List<DownloadInfo>
     fun getByGroup(group: Int): List<DownloadInfo>
-    fun getDownloadsInGroupWithStatus(groupId: Int, status: Status): List<DownloadInfo>
+    fun getDownloadsInGroupWithStatus(groupId: Int, statuses: List<Status>): List<DownloadInfo>
     fun getDownloadsByRequestIdentifier(identifier: Long): List<DownloadInfo>
     fun getPendingDownloadsSorted(): List<DownloadInfo>
     fun sanitizeOnFirstEntry()

--- a/fetch2/src/main/java/com/tonyodev/fetch2/database/DatabaseManagerImpl.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/database/DatabaseManagerImpl.kt
@@ -197,12 +197,14 @@ class DatabaseManagerImpl constructor(context: Context,
         }
     }
 
-    override fun getDownloadsInGroupWithStatus(groupId: Int, status: Status): List<DownloadInfo> {
+    override fun getDownloadsInGroupWithStatus(groupId: Int, statuses: List<Status>): List<DownloadInfo> {
         synchronized(lock) {
             throwExceptionIfClosed()
-            var downloads = requestDatabase.requestDao().getByGroupWithStatus(groupId, status)
+            var downloads = requestDatabase.requestDao().getByGroupWithStatus(groupId, statuses.toMutableList())
             if (sanitize(downloads)) {
-                downloads = downloads.filter { it.status == status }
+                downloads = downloads.filter { download ->
+                    statuses.any { it == download.status }
+                }
             }
             return downloads
         }

--- a/fetch2/src/main/java/com/tonyodev/fetch2/database/DownloadDao.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/database/DownloadDao.kt
@@ -54,8 +54,8 @@ interface DownloadDao {
     @Query("SELECT * FROM $TABLE_NAME WHERE $COLUMN_GROUP = :group")
     fun getByGroup(group: Int): List<DownloadInfo>
 
-    @Query("SELECT * FROM $TABLE_NAME WHERE $COLUMN_GROUP = :group AND $COLUMN_STATUS = :status")
-    fun getByGroupWithStatus(group: Int, status: Status): List<DownloadInfo>
+    @Query("SELECT * FROM $TABLE_NAME WHERE $COLUMN_GROUP = :group AND $COLUMN_STATUS IN (:statuses)")
+    fun getByGroupWithStatus(group: Int, statuses: MutableList<Status>): List<DownloadInfo>
 
     @Query("SELECT * FROM $TABLE_NAME WHERE $COLUMN_STATUS = :status ORDER BY $COLUMN_PRIORITY DESC, $COLUMN_CREATED ASC")
     fun getPendingDownloadsSorted(status: Status): List<DownloadInfo>

--- a/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandler.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandler.kt
@@ -27,12 +27,12 @@ interface FetchHandler : Closeable {
     fun removeGroup(id: Int): List<Download>
     fun removeAll(): List<Download>
     fun removeAllWithStatus(status: Status): List<Download>
-    fun removeAllInGroupWithStatus(groupId: Int, status: Status): List<Download>
+    fun removeAllInGroupWithStatus(groupId: Int, statuses: List<Status>): List<Download>
     fun delete(ids: List<Int>): List<Download>
     fun deleteGroup(id: Int): List<Download>
     fun deleteAll(): List<Download>
     fun deleteAllWithStatus(status: Status): List<Download>
-    fun deleteAllInGroupWithStatus(groupId: Int, status: Status): List<Download>
+    fun deleteAllInGroupWithStatus(groupId: Int, statuses: List<Status>): List<Download>
     fun cancel(ids: List<Int>): List<Download>
     fun cancelGroup(id: Int): List<Download>
     fun cancelAll(): List<Download>
@@ -43,7 +43,7 @@ interface FetchHandler : Closeable {
     fun getDownloads(idList: List<Int>): List<Download>
     fun getDownloadsInGroup(id: Int): List<Download>
     fun getDownloadsWithStatus(status: Status): List<Download>
-    fun getDownloadsInGroupWithStatus(groupId: Int, status: Status): List<Download>
+    fun getDownloadsInGroupWithStatus(groupId: Int, statuses: List<Status>): List<Download>
     fun getDownloadsByRequestIdentifier(identifier: Long): List<Download>
     fun setGlobalNetworkType(networkType: NetworkType)
     fun enableLogging(enabled: Boolean)

--- a/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandlerImpl.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandlerImpl.kt
@@ -237,8 +237,8 @@ class FetchHandlerImpl(private val namespace: String,
         return removeDownloads(databaseManager.getByStatus(status))
     }
 
-    override fun removeAllInGroupWithStatus(groupId: Int, status: Status): List<Download> {
-        return removeDownloads(databaseManager.getDownloadsInGroupWithStatus(groupId, status))
+    override fun removeAllInGroupWithStatus(groupId: Int, statuses: List<Status>): List<Download> {
+        return removeDownloads(databaseManager.getDownloadsInGroupWithStatus(groupId, statuses))
     }
 
     private fun removeDownloads(downloads: List<DownloadInfo>): List<Download> {
@@ -267,8 +267,8 @@ class FetchHandlerImpl(private val namespace: String,
         return deleteDownloads(databaseManager.getByStatus(status))
     }
 
-    override fun deleteAllInGroupWithStatus(groupId: Int, status: Status): List<Download> {
-        return deleteDownloads(databaseManager.getDownloadsInGroupWithStatus(groupId, status))
+    override fun deleteAllInGroupWithStatus(groupId: Int, statuses: List<Status>): List<Download> {
+        return deleteDownloads(databaseManager.getDownloadsInGroupWithStatus(groupId, statuses))
     }
 
     private fun deleteDownloads(downloads: List<DownloadInfo>): List<Download> {
@@ -390,8 +390,8 @@ class FetchHandlerImpl(private val namespace: String,
         return databaseManager.getByStatus(status)
     }
 
-    override fun getDownloadsInGroupWithStatus(groupId: Int, status: Status): List<Download> {
-        return databaseManager.getDownloadsInGroupWithStatus(groupId, status)
+    override fun getDownloadsInGroupWithStatus(groupId: Int, statuses: List<Status>): List<Download> {
+        return databaseManager.getDownloadsInGroupWithStatus(groupId, statuses)
     }
 
     override fun getDownloadsByRequestIdentifier(identifier: Long): List<Download> {

--- a/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchImpl.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchImpl.kt
@@ -364,12 +364,12 @@ open class FetchImpl constructor(override val namespace: String,
         return removeAllWithStatus(status, null, null)
     }
 
-    override fun removeAllInGroupWithStatus(id: Int, status: Status, func: Func<List<Download>>?, func2: Func<Error>?): Fetch {
-        return executeRemoveAction({ fetchHandler.removeAllInGroupWithStatus(id, status) }, func, func2)
+    override fun removeAllInGroupWithStatus(id: Int, statuses: List<Status>, func: Func<List<Download>>?, func2: Func<Error>?): Fetch {
+        return executeRemoveAction({ fetchHandler.removeAllInGroupWithStatus(id, statuses) }, func, func2)
     }
 
-    override fun removeAllInGroupWithStatus(id: Int, status: Status): Fetch {
-        return removeAllInGroupWithStatus(id, status, null, null)
+    override fun removeAllInGroupWithStatus(id: Int, statuses: List<Status>): Fetch {
+        return removeAllInGroupWithStatus(id, statuses, null, null)
     }
 
     private fun executeRemoveAction(downloadAction: () -> List<Download>, func: Func<List<Download>>?, func2: Func<Error>?): Fetch {
@@ -446,12 +446,12 @@ open class FetchImpl constructor(override val namespace: String,
         return deleteAllWithStatus(status, null, null)
     }
 
-    override fun deleteAllInGroupWithStatus(id: Int, status: Status, func: Func<List<Download>>?, func2: Func<Error>?): Fetch {
-        return executeDeleteAction({ fetchHandler.deleteAllInGroupWithStatus(id, status) }, func, func2)
+    override fun deleteAllInGroupWithStatus(id: Int, statuses: List<Status>, func: Func<List<Download>>?, func2: Func<Error>?): Fetch {
+        return executeDeleteAction({ fetchHandler.deleteAllInGroupWithStatus(id, statuses) }, func, func2)
     }
 
-    override fun deleteAllInGroupWithStatus(id: Int, status: Status): Fetch {
-        return deleteAllInGroupWithStatus(id, status, null, null)
+    override fun deleteAllInGroupWithStatus(id: Int, statuses: List<Status>): Fetch {
+        return deleteAllInGroupWithStatus(id, statuses, null, null)
     }
 
     private fun executeDeleteAction(downloadAction: () -> List<Download>, func: Func<List<Download>>?, func2: Func<Error>?): Fetch {
@@ -750,11 +750,11 @@ open class FetchImpl constructor(override val namespace: String,
         }
     }
 
-    override fun getDownloadsInGroupWithStatus(groupId: Int, status: Status, func: Func<List<Download>>): Fetch {
+    override fun getDownloadsInGroupWithStatus(groupId: Int, statuses: List<Status>, func: Func<List<Download>>): Fetch {
         synchronized(lock) {
             throwExceptionIfClosed()
             handlerWrapper.post {
-                val downloads = fetchHandler.getDownloadsInGroupWithStatus(groupId, status)
+                val downloads = fetchHandler.getDownloadsInGroupWithStatus(groupId, statuses)
                 uiHandler.post {
                     func.call(downloads)
                 }

--- a/fetch2rx/src/main/java/com/tonyodev/fetch2rx/RxFetch.kt
+++ b/fetch2rx/src/main/java/com/tonyodev/fetch2rx/RxFetch.kt
@@ -184,11 +184,11 @@ interface RxFetch {
     /**
      * Remove all downloads with the specified group and status in this instance of Fetch.
      * The downloaded files for removed downloads are not deleted.
-     * @param status status
+     * @param statuses statuses
      * @throws FetchException if this instance of Fetch has been closed.
      * @return Convertible with list of downloads that were removed.
      * */
-    fun removeAllInGroupWithStatus(id: Int, status: Status): Convertible<List<Download>>
+    fun removeAllInGroupWithStatus(id: Int, statuses: List<Status>): Convertible<List<Download>>
 
     /**
      * Delete a list of downloads managed by this instance of Fetch.
@@ -237,11 +237,11 @@ interface RxFetch {
     /**
      * Deletes all downloads with the specified group and status in this instance of Fetch.
      * The downloaded files are also deleted.
-     * @param status status
+     * @param statuses statuses
      * @throws FetchException if this instance of Fetch has been closed.
      * @return Convertible with list of downloads that were deleted.
      * */
-    fun deleteAllInGroupWithStatus(id: Int, status: Status): Convertible<List<Download>>
+    fun deleteAllInGroupWithStatus(id: Int, statuses: List<Status>): Convertible<List<Download>>
 
     /**
      * Cancel a list of non completed downloads managed by this instance of Fetch.
@@ -357,11 +357,11 @@ interface RxFetch {
      * Gets all downloads in a specific group with a specific status.
      * @see com.tonyodev.fetch2.Status
      * @param groupId group id to query.
-     * @param status Status to query.
+     * @param statuses Statuses to query.
      * @throws FetchException if this instance of Fetch has been closed.
      * @return Convertible with results.
      * */
-    fun getDownloadsInGroupWithStatus(groupId: Int, status: Status): Convertible<List<Download>>
+    fun getDownloadsInGroupWithStatus(groupId: Int, status: List<Status>): Convertible<List<Download>>
 
     /**
      * Gets all downloads containing the identifier.

--- a/fetch2rx/src/main/java/com/tonyodev/fetch2rx/RxFetchImpl.kt
+++ b/fetch2rx/src/main/java/com/tonyodev/fetch2rx/RxFetchImpl.kt
@@ -368,7 +368,7 @@ open class RxFetchImpl(override val namespace: String,
         }
     }
 
-    override fun removeAllInGroupWithStatus(id: Int, status: Status): Convertible<List<Download>> {
+    override fun removeAllInGroupWithStatus(id: Int, status: List<Status>): Convertible<List<Download>> {
         return synchronized(lock) {
             throwExceptionIfClosed()
             Flowable.just(Pair(id, status))
@@ -488,10 +488,10 @@ open class RxFetchImpl(override val namespace: String,
         }
     }
 
-    override fun deleteAllInGroupWithStatus(id: Int, status: Status): Convertible<List<Download>> {
+    override fun deleteAllInGroupWithStatus(id: Int, statuses: List<Status>): Convertible<List<Download>> {
         return synchronized(lock) {
             throwExceptionIfClosed()
-            Flowable.just(Pair(id, status))
+            Flowable.just(Pair(id, statuses))
                     .subscribeOn(scheduler)
                     .flatMap {
                         throwExceptionIfClosed()
@@ -804,7 +804,7 @@ open class RxFetchImpl(override val namespace: String,
         }
     }
 
-    override fun getDownloadsInGroupWithStatus(groupId: Int, status: Status): Convertible<List<Download>> {
+    override fun getDownloadsInGroupWithStatus(groupId: Int, status: List<Status>): Convertible<List<Download>> {
         return synchronized(lock) {
             throwExceptionIfClosed()
             Flowable.just(status)


### PR DESCRIPTION
Hi @tonyofrancis 

This PR is about adding an ability to fetch group downloads by multiple statuses.
If you are ok with this changes then I may update the rest of methods that query by Status. 

Few notes:
- Firstly I wanted to use `vararg statuses: Status`, however as Status is not always the last parameter it may be error prone in situations like `FetchImpl::removeAllWithStatus(statuses, null, null)`. It would think that two `nulls` are of type Status as well so we'd need to use it like `FetchImpl::removeAllWithStatus(statuses, func1 = null, func2 = null)`.
Besides that lists are more powerful.
- If you'd wonder why there is a `MutableList` in `DownloadsDao`, it is because Room doesn't handle Kotlin List. https://stackoverflow.com/questions/46785534/android-room-error-typeconverter-not-recognised-for-list-of-enums
- It would be nice to rewrite tests to Kotlin in future as they are pretty long because of Java :)