### PR TITLE
Add a new enqueue action where files are created only when the download starts

### DIFF
--- a/fetch2/src/main/java/com/tonyodev/fetch2/EnqueueAction.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/EnqueueAction.kt
@@ -27,7 +27,9 @@ enum class EnqueueAction(val value: Int) {
      * Note: If download is existing, Fetch will update the old request/download with the new settings on
      * from the request object.
      * */
-    UPDATE_ACCORDINGLY(3);
+    UPDATE_ACCORDINGLY(3),
+
+    CREATE_FILE_ON_DOWNLOAD(4);
 
     companion object {
 
@@ -37,6 +39,7 @@ enum class EnqueueAction(val value: Int) {
                 1 -> INCREMENT_FILE_NAME
                 2 -> DO_NOT_ENQUEUE_IF_EXISTING
                 3 -> UPDATE_ACCORDINGLY
+                4 -> CREATE_FILE_ON_DOWNLOAD
                 else -> REPLACE_EXISTING
             }
         }

--- a/fetch2/src/main/java/com/tonyodev/fetch2/downloader/DownloadManagerImpl.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/downloader/DownloadManagerImpl.kt
@@ -88,6 +88,10 @@ class DownloadManagerImpl(private val httpDownloader: Downloader<*, *>,
                         val fileDownloader = getNewFileDownloaderForDownload(download)
                         val runDownload = synchronized(lock) {
                             if (currentDownloadsMap.containsKey(download.id)) {
+                                if(download.enqueueAction === EnqueueAction.CREATE_FILE_ON_DOWNLOAD &&
+                                        !storageResolver.fileExists(download.file)) {
+                                    storageResolver.createFile(download.file, false);
+                                }
                                 fileDownloader.delegate = getFileDownloaderDelegate()
                                 currentDownloadsMap[download.id] = fileDownloader
                                 downloadManagerCoordinator.addFileDownloader(download.id, fileDownloader)

--- a/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandlerImpl.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandlerImpl.kt
@@ -98,7 +98,7 @@ class FetchHandlerImpl(private val namespace: String,
         cancelDownloadsIfDownloading(listOf(downloadInfo))
         var existingDownload = fetchDatabaseManagerWrapper.getByFile(downloadInfo.file)
         if (existingDownload == null) {
-            if (downloadInfo.enqueueAction != EnqueueAction.INCREMENT_FILE_NAME) {
+            if (downloadInfo.enqueueAction != EnqueueAction.INCREMENT_FILE_NAME && downloadInfo.enqueueAction != EnqueueAction.CREATE_FILE_ON_DOWNLOAD) {
                 storageResolver.createFile(downloadInfo.file)
             }
         } else {
@@ -149,6 +149,13 @@ class FetchHandlerImpl(private val namespace: String,
                 }
             }
             EnqueueAction.DO_NOT_ENQUEUE_IF_EXISTING -> {
+                if (existingDownload != null) {
+                    throw FetchException(REQUEST_WITH_FILE_PATH_ALREADY_EXIST)
+                } else {
+                    false
+                }
+            }
+            EnqueueAction.CREATE_FILE_ON_DOWNLOAD -> {
                 if (existingDownload != null) {
                     throw FetchException(REQUEST_WITH_FILE_PATH_ALREADY_EXIST)
                 } else {


### PR DESCRIPTION
I added a new type of `EnqueueAction` type, that allows a file to be created only when the download actually starts. 
This should have absolutely no impact on the other types of `EnqueueAction` used everywhere else.