### PR TITLE
Close will not throw FetchException anymore

### DIFF
--- a/fetch2/src/main/java/com/tonyodev/fetch2/Fetch.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/Fetch.kt
@@ -826,7 +826,6 @@ interface Fetch {
     /** Releases held resources and the namespace used by this Fetch instance.
      * Once closed this instance cannot be reused but the namespace can be reused
      * by a new instance of Fetch.
-     * @throws FetchException if this instance of Fetch has been closed.
      * */
     fun close()
 


### PR DESCRIPTION
Close will not throw FetchException anymore if closed before as mentioned [here](https://github.com/tonyofrancis/Fetch/releases/tag/2.1.0-RC1).