### PR TITLE
Accept headers in case-insensitive way

### DIFF
--- a/fetch2/src/main/java/com/tonyodev/fetch2/HttpUrlConnectionDownloader.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/HttpUrlConnectionDownloader.kt
@@ -56,12 +56,12 @@ open class HttpUrlConnectionDownloader @JvmOverloads constructor(
             client.addRequestProperty("Referer", referer)
         }
         client.connect()
-        var responseHeaders = client.headerFields
+        var responseHeaders = provideHeaders(client.headerFields)
         var code = client.responseCode
         if ((code == HttpURLConnection.HTTP_MOVED_TEMP
                 || code == HttpURLConnection.HTTP_MOVED_PERM
-                || code == HttpURLConnection.HTTP_SEE_OTHER) && responseHeaders.containsKey("Location")) {
-            httpUrl = URL(responseHeaders["Location"]?.firstOrNull() ?: "")
+                || code == HttpURLConnection.HTTP_SEE_OTHER) && responseHeaders.containsKey("location")) {
+            httpUrl = URL(responseHeaders["location"]?.firstOrNull() ?: "")
             client = httpUrl.openConnection() as HttpURLConnection
             onPreClientExecute(client, request)
             if (client.getRequestProperty("Referer") == null) {
@@ -69,7 +69,7 @@ open class HttpUrlConnectionDownloader @JvmOverloads constructor(
                 client.addRequestProperty("Referer", referer)
             }
             client.connect()
-            responseHeaders = client.headerFields
+            responseHeaders = provideHeaders(client.headerFields)
             code = client.responseCode
         }
         var success = false
@@ -87,7 +87,7 @@ open class HttpUrlConnectionDownloader @JvmOverloads constructor(
         }
 
         val acceptsRanges = code == HttpURLConnection.HTTP_PARTIAL ||
-                responseHeaders["Accept-Ranges"]?.firstOrNull() == "bytes"
+                responseHeaders["accept-ranges"]?.firstOrNull() == "bytes"
 
         onServerResponse(request, Downloader.Response(
                 code = code,
@@ -128,7 +128,7 @@ open class HttpUrlConnectionDownloader @JvmOverloads constructor(
     }
 
     override fun getContentHash(responseHeaders: MutableMap<String, List<String>>): String {
-        return responseHeaders["Content-MD5"]?.firstOrNull() ?: ""
+        return responseHeaders["content-md5"]?.firstOrNull() ?: ""
     }
 
     override fun close() {
@@ -144,6 +144,21 @@ open class HttpUrlConnectionDownloader @JvmOverloads constructor(
         } catch (e: Exception) {
 
         }
+    }
+
+    private fun provideHeaders(headers: MutableMap<String, List<String>>): MutableMap<String, List<String>> {
+        val iterator = headers.iterator()
+
+        while (iterator.hasNext()) {
+            val (key, values) = iterator.next()
+            if (key != key.toLowerCase()) {
+
+                headers[key.toLowerCase()] = values
+                iterator.remove()
+            }
+        }
+
+        return headers
     }
 
     override fun getFileSlicingCount(request: Downloader.ServerRequest, contentLength: Long): Int? {

--- a/fetch2core/src/main/java/com/tonyodev/fetch2core/FetchCoreUtils.kt
+++ b/fetch2core/src/main/java/com/tonyodev/fetch2core/FetchCoreUtils.kt
@@ -220,11 +220,11 @@ fun getFileMd5String(file: String): String? {
 }
 
 fun isParallelDownloadingSupported(responseHeaders: Map<String, List<String>>): Boolean {
-    val transferEncoding = responseHeaders["Transfer-Encoding"]?.firstOrNull()
-            ?: responseHeaders["TransferEncoding"]?.firstOrNull()
+    val transferEncoding = responseHeaders["transfer-encoding"]?.firstOrNull()
+            ?: responseHeaders["transferencoding"]?.firstOrNull()
             ?: ""
-    val contentLength = (responseHeaders["Content-Length"]?.firstOrNull()?.toLongOrNull()
-            ?: responseHeaders["ContentLength"]?.firstOrNull()?.toLongOrNull())
+    val contentLength = (responseHeaders["content-length"]?.firstOrNull()?.toLongOrNull()
+            ?: responseHeaders["contentlength"]?.firstOrNull()?.toLongOrNull())
             ?: -1L
     return transferEncoding != "chunked" && contentLength > -1L
 }
@@ -339,15 +339,15 @@ fun getSimpleInterruptMonitor() = object : InterruptMonitor {
 
 fun getContentLengthFromHeader(headers: Map<String, List<String>>, defaultValue: Long): Long {
     var contentLength = defaultValue
-    if (headers.containsKey("Content-Length")) {
-        val size = headers["Content-Length"]?.firstOrNull()?.toLongOrNull()
+    if (headers.containsKey("content-length")) {
+        val size = headers["content-length"]?.firstOrNull()?.toLongOrNull()
         if (size != null && size > 0) {
             contentLength = size
             return contentLength
         }
     }
-    if (headers.containsKey("Content-Range")) {
-        val value = headers["Content-Range"]?.firstOrNull()
+    if (headers.containsKey("content-range")) {
+        val value = headers["content-range"]?.firstOrNull()
         if (value != null) {
             val index = value.lastIndexOf("/")
             if (index != -1 && ((index + 1) < value.length)) {

--- a/fetch2core/src/main/java/com/tonyodev/fetch2core/server/FetchFileResourceTransporter.kt
+++ b/fetch2core/src/main/java/com/tonyodev/fetch2core/server/FetchFileResourceTransporter.kt
@@ -114,7 +114,7 @@ class FetchFileResourceTransporter(private val client: Socket = Socket()) : File
         return synchronized(lock) {
             throwExceptionIfClosed()
             throwIfNotConnected()
-            val json = JSONObject(dataInput.readUTF())
+            val json = JSONObject(dataInput.readUTF().toLowerCase())
             val status = json.getInt(FIELD_STATUS)
             val requestType = json.getInt(FIELD_TYPE)
             val connection = json.getInt(FIELD_CONNECTION)

--- a/fetch2core/src/main/java/com/tonyodev/fetch2core/server/FileResponse.kt
+++ b/fetch2core/src/main/java/com/tonyodev/fetch2core/server/FileResponse.kt
@@ -52,13 +52,13 @@ data class FileResponse(val status: Int = HttpURLConnection.HTTP_UNSUPPORTED_TYP
 
         const val CLOSE_CONNECTION = 0
         const val OPEN_CONNECTION = 1
-        const val FIELD_STATUS = "Status"
-        const val FIELD_TYPE = "Type"
-        const val FIELD_CONNECTION = "Connection"
-        const val FIELD_DATE = "Date"
-        const val FIELD_CONTENT_LENGTH = "Content-Length"
-        const val FIELD_MD5 = "Md5"
-        const val FIELD_SESSION_ID = "SessionId"
+        const val FIELD_STATUS = "status"
+        const val FIELD_TYPE = "type"
+        const val FIELD_CONNECTION = "connection"
+        const val FIELD_DATE = "date"
+        const val FIELD_CONTENT_LENGTH = "content-length"
+        const val FIELD_MD5 = "md5"
+        const val FIELD_SESSION_ID = "sessionid"
 
 
         override fun createFromParcel(source: Parcel): FileResponse {

--- a/fetch2okhttp/src/main/java/com/tonyodev/fetch2okhttp/OkHttpDownloader.kt
+++ b/fetch2okhttp/src/main/java/com/tonyodev/fetch2okhttp/OkHttpDownloader.kt
@@ -55,7 +55,7 @@ open class OkHttpDownloader @JvmOverloads constructor(
         for (i in 0 until okResponseHeaders.size()) {
             val key = okResponseHeaders.name(i)
             val values = okResponseHeaders.values(key)
-            headers[key] = values
+            headers[key.toLowerCase()] = values
         }
         return headers
     }
@@ -89,9 +89,9 @@ open class OkHttpDownloader @JvmOverloads constructor(
         var code = okHttpResponse.code()
         if ((code == HttpURLConnection.HTTP_MOVED_TEMP
                         || code == HttpURLConnection.HTTP_MOVED_PERM
-                        || code == HttpURLConnection.HTTP_SEE_OTHER) && responseHeaders.containsKey("Location")) {
+                        || code == HttpURLConnection.HTTP_SEE_OTHER) && responseHeaders.containsKey("location")) {
             okHttpRequest = onPreClientExecute(client, getRedirectedServerRequest(request,
-                    responseHeaders["Location"]?.firstOrNull() ?: ""))
+                    responseHeaders["location"]?.firstOrNull() ?: ""))
             if (okHttpRequest.header("Referer") == null) {
                 val referer = getRefererFromUrl(request.url)
                 okHttpRequest = okHttpRequest.newBuilder()
@@ -114,11 +114,11 @@ open class OkHttpDownloader @JvmOverloads constructor(
         val hash = getContentHash(responseHeaders)
 
         if (contentLength < 1) {
-            contentLength = responseHeaders["Content-Length"]?.firstOrNull()?.toLong() ?: -1L
+            contentLength = responseHeaders["content-length"]?.firstOrNull()?.toLong() ?: -1L
         }
 
         val acceptsRanges = code == HttpURLConnection.HTTP_PARTIAL ||
-                responseHeaders["Accept-Ranges"]?.firstOrNull() == "bytes"
+                responseHeaders["accept-ranges"]?.firstOrNull() == "bytes"
 
         onServerResponse(request, Downloader.Response(
                 code = code,
@@ -147,7 +147,7 @@ open class OkHttpDownloader @JvmOverloads constructor(
     }
 
     override fun getContentHash(responseHeaders: MutableMap<String, List<String>>): String {
-        return responseHeaders["Content-MD5"]?.firstOrNull() ?: ""
+        return responseHeaders["content-md5"]?.firstOrNull() ?: ""
     }
 
     override fun disconnect(response: Downloader.Response) {


### PR DESCRIPTION
Hi
Headers are case-insensitive based on [RFC 2616 - "Hypertext Transfer Protocol -- HTTP/1.1", Section 4.2, "Message Headers"](https://www.w3.org/Protocols/rfc2616/rfc2616-sec4.html#sec4.2)
For example [cowboy](https://github.com/ninenines/cowboy) sends headers in lowercase.
I changed all header readings at first to lowercase, and then header checks become lowercase too.

Should there a database migrations too?