### PR TITLE
Fix unnecessary delay to starting a sequential download.

### DIFF
--- a/fetch2/src/main/java/com/tonyodev/fetch2/HttpUrlConnectionDownloader.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/HttpUrlConnectionDownloader.kt
@@ -193,7 +193,13 @@ open class HttpUrlConnectionDownloader @JvmOverloads constructor(
     }
 
     override fun getRequestSupportedFileDownloaderTypes(request: Downloader.ServerRequest): Set<Downloader.FileDownloaderType> {
-        if(fileDownloaderType == Downloader.FileDownloaderType.SEQUENTIAL) {
+        return when (fileDownloaderType) {
+            Downloader.FileDownloaderType.SEQUENTIAL -> mutableSetOf(fileDownloaderType)
+            else -> try {
+                getRequestSupportedFileDownloaderTypes(request, this)
+            } catch (e: Exception) {
+                mutableSetOf(fileDownloaderType)
+            }
             return mutableSetOf(fileDownloaderType)
         }
 

--- a/fetch2/src/main/java/com/tonyodev/fetch2/HttpUrlConnectionDownloader.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/HttpUrlConnectionDownloader.kt
@@ -193,6 +193,10 @@ open class HttpUrlConnectionDownloader @JvmOverloads constructor(
     }
 
     override fun getRequestSupportedFileDownloaderTypes(request: Downloader.ServerRequest): Set<Downloader.FileDownloaderType> {
+        if(fileDownloaderType == Downloader.FileDownloaderType.SEQUENTIAL) {
+            return mutableSetOf(fileDownloaderType)
+        }
+
         return try {
             getRequestSupportedFileDownloaderTypes(request, this)
         } catch (e: Exception) {

--- a/fetch2okhttp/src/main/java/com/tonyodev/fetch2okhttp/OkHttpDownloader.kt
+++ b/fetch2okhttp/src/main/java/com/tonyodev/fetch2okhttp/OkHttpDownloader.kt
@@ -209,6 +209,10 @@ open class OkHttpDownloader @JvmOverloads constructor(
     }
 
     override fun getRequestSupportedFileDownloaderTypes(request: Downloader.ServerRequest): Set<Downloader.FileDownloaderType> {
+        if(fileDownloaderType == Downloader.FileDownloaderType.SEQUENTIAL) {
+            return mutableSetOf(fileDownloaderType)
+        }
+
         return try {
             getRequestSupportedFileDownloaderTypes(request, this)
         } catch (e: Exception) {


### PR DESCRIPTION
When the downloader is sequential, there is no need to make a request to
the server to check if the server supports parallel downloads. This
results in an unnecessary delay to starting the request. 

I think this may also be related to issue #456 (slow download start). I used a profiler
trace that was started on the onDownloadedAdded and then stopped the profiler in
onDownloadStarted. The profiler trace showed that the majority of the delay (approx 
1.5 seconds on the emulator with a broadband connection) was caused by the request 
checking for parallel downloading support.

I have uploaded the trace file here:
[https://www.ustadmobile.com/files/fetchstart.trace](https://www.ustadmobile.com/files/fetchstart.trace)

This modification adds only 6 lines. The getRequestSupportedFileDownloaderTypes
on HttpUrlConnectionDownloader and OkHttpDownloader simply checks if the
downloader is sequential. If it is, then the sequential downloader type
is returned immediately without querying the server for the request.
