### PR TITLE
Create a new method for batch inserting a list of downloads

### DIFF
--- a/fetch2/src/androidTest/java/com/tonyodev/fetch2/FetchHandlerInstrumentedTest.java
+++ b/fetch2/src/androidTest/java/com/tonyodev/fetch2/FetchHandlerInstrumentedTest.java
@@ -296,6 +296,19 @@ public class FetchHandlerInstrumentedTest {
     }
 
     @Test
+    public void insertBatch() throws Exception {
+        fetchHandler.deleteAll();
+        final int size = 1000;
+        List<Request> requestList = getTestRequestList(size);
+        List<Pair<DownloadInfo, Boolean>> pairs = fetchHandler.enqueueBatch(requestList);
+        assertEquals(1000, pairs.size());
+        for (Pair<DownloadInfo, Boolean> downloadInfoPair : pairs) {
+            assertNotNull(downloadInfoPair);
+            assertTrue(downloadInfoPair.component2());
+        }
+    }
+
+    @Test
     public void deleteWithId() throws Exception {
         fetchHandler.deleteAll();
         final Request request = getTestRequest();

--- a/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandler.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandler.kt
@@ -1,6 +1,7 @@
 package com.tonyodev.fetch2.fetch
 
 import com.tonyodev.fetch2.*
+import com.tonyodev.fetch2.database.DownloadInfo
 import com.tonyodev.fetch2core.*
 import java.io.Closeable
 
@@ -12,6 +13,7 @@ interface FetchHandler : Closeable {
     fun init()
     fun enqueue(request: Request): Pair<Download, Error>
     fun enqueue(requests: List<Request>): List<Pair<Download, Error>>
+    fun enqueueBatch(requests: List<Request>): List<Pair<DownloadInfo, Boolean>>
     fun enqueueCompletedDownload(completedDownload: CompletedDownload): Download
     fun enqueueCompletedDownloads(completedDownloads: List<CompletedDownload>): List<Download>
     fun pause(ids: List<Int>): List<Download>

--- a/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandlerImpl.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/fetch/FetchHandlerImpl.kt
@@ -57,6 +57,28 @@ class FetchHandlerImpl(private val namespace: String,
         return enqueueRequests(requests)
     }
 
+    override fun enqueueBatch(requests: List<Request>): List<Pair<DownloadInfo, Boolean>> {
+        val downloadInfos = mutableListOf<DownloadInfo>()
+        requests.forEach {
+            val downloadInfo = it.toDownloadInfo(fetchDatabaseManagerWrapper.getNewDownloadInfoInstance())
+
+            downloadInfo.namespace = namespace
+            val existing = prepareDownloadInfoForEnqueue(downloadInfo)
+            downloadInfo.status = if (it.downloadOnEnqueue) {
+                Status.QUEUED
+            } else {
+                Status.ADDED
+            }
+
+            if (downloadInfo.status != Status.COMPLETED && !existing) {
+                downloadInfos.add(downloadInfo);
+            }
+        }
+        val results = fetchDatabaseManagerWrapper.insert(downloadInfos)
+        startPriorityQueueIfNotStarted()
+        return results
+    }
+
     private fun enqueueRequests(requests: List<Request>): List<Pair<Download, Error>> {
         val results = mutableListOf<Pair<Download, Error>>()
         requests.forEach {


### PR DESCRIPTION
When enqueuing a large list of downloads (users have reported that several thousands downloads have the problem), the enqueue process could be very long, something like several minutes.

After doing a review of the code used to enqueue a list of requests, I thought that this lib could use a new method to quickly add a batch of requests directly in the db, without looping on the list and inserting all in batch. 

This would be really useful for downloading a very large batch of files. 

I would greatly appreciate a quick review on this, and if you could let me know what I could do to improve it if needed ! 

Thanks