### PR TITLE
Fix mistake (and typos) in documentation for enqueueAction

### DIFF
--- a/fetch2/src/main/java/com/tonyodev/fetch2/RequestInfo.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/RequestInfo.kt
@@ -43,8 +43,7 @@ open class RequestInfo : Serializable {
 
     /**
      * Action used by Fetch when enqueuing a request and a previous request with the
-     * same file is already being managed. Default EnqueueAction.REPLACE_EXISTING
-     * which will replaces the existing request.
+     * same file is already being managed. Default is [EnqueueAction.UPDATE_ACCORDINGLY].
      * */
     var enqueueAction = defaultEnqueueAction
 


### PR DESCRIPTION
The default enqueueAction is UPDATE_ACCORDINGLY but this piece of documentation says it's REPLACE_EXISTING.

Found this while investigating #582 and #403