### PR TITLE
Range end handling 

### DIFF
--- a/fetch2/src/main/java/com/tonyodev/fetch2/downloader/ParallelFileDownloaderImpl.kt
+++ b/fetch2/src/main/java/com/tonyodev/fetch2/downloader/ParallelFileDownloaderImpl.kt
@@ -428,7 +428,7 @@ class ParallelFileDownloaderImpl(private val initialDownload: Download,
                     downloadBlock.downloadedBytes = fileSlice.downloaded
                     downloadBlock.startByte = fileSlice.startBytes
                     downloadBlock.endByte = fileSlice.endBytes
-                    val downloadRequest = getRequestForDownload(download = downloadInfo, rangeStart = fileSlice.startBytes + fileSlice.downloaded, segment = fileSlice.position + 1)
+                    val downloadRequest = getRequestForDownload(download = downloadInfo, rangeStart = fileSlice.startBytes + fileSlice.downloaded, rangeEnd = fileSlice.endBytes, segment = fileSlice.position + 1)
                     var downloadResponse: Downloader.Response? = null
                     var saveRandomAccessFile: RandomAccessFile? = null
                     try {


### PR DESCRIPTION
I think it would be good to use rangeEnd properly in ParallelFileDownloaderImpl. Noticed it wasn't being use anywhere and when logging http request it looks better... Also some CDNs can cache the chunks better with proper range headers 😁